### PR TITLE
Update for new SDK Call object model

### DIFF
--- a/ObjCVoiceCallKitQuickstart/ViewController.m
+++ b/ObjCVoiceCallKitQuickstart/ViewController.m
@@ -304,6 +304,8 @@ static NSString *const kAccessTokenEndpoint = @"/accessToken";
     if (self.call) {
         self.call.uuid = [action callUUID];
     }
+    
+    self.callInvite = nil;
 
     [action fulfill];
 }
@@ -315,6 +317,7 @@ static NSString *const kAccessTokenEndpoint = @"/accessToken";
 
     if (self.callInvite && self.callInvite.state == TVOCallInviteStatePending) {
         [self.callInvite reject];
+        self.callInvite = nil;
     } else if (self.call) {
         [self.call disconnect];
     }

--- a/Podfile
+++ b/Podfile
@@ -4,5 +4,5 @@ source 'https://github.com/CocoaPods/Specs.git'
 target 'ObjCVoiceCallKitQuickstart' do
   use_frameworks!
 
-  pod 'TwilioVoiceClient', '=2.0.0-beta5'
+  pod 'TwilioVoiceClient', '=2.0.0-beta6'
 end


### PR DESCRIPTION
The latest Voice SDK has consolidated the `TVOIncomingCall` & `TVOOutgoingCall` objects into an unified `TVOCall` object. A new `TVOCallInvite` object is also introduced to abstract the incoming attributes from the original `TVOIncomingCall` object.

Also added some sample code to demonstrate how to use the `TVOCall.disconnect` method to hang up the call properly.